### PR TITLE
Fix missing kubeconfig link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ List tenant Kubernetes instances:
 kindred tenant list
 ```
 
-Get [kubeconfig] for a tenant instance:
+Get
+[kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/)
+for a tenant instance:
 ```
 kindred tenant config <instance-identifier>
 ```


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>